### PR TITLE
Remove federated query param on logout if false

### DIFF
--- a/lib/src/web_auth.dart
+++ b/lib/src/web_auth.dart
@@ -123,8 +123,9 @@ class WebAuth {
             await _channel.invokeMethod('bundleIdentifier');
         String redirectUri =
             '$bundleIdentifier://${this.domain}/$platformName/$bundleIdentifier/callback';
+        String federatedParam = federated ? '&federated=true' : '';
         String logoutUrl = Uri.encodeFull(
-            '${Constant.logout(this.domain)}?client_id=${this.clientId}&federated=$federated&returnTo=$redirectUri');
+            '${Constant.logout(this.domain)}?client_id=${this.clientId}${federatedParam}&returnTo=$redirectUri');
         await _channel.invokeMethod('showUrl', {'url': logoutUrl});
       } on PlatformException catch (e) {
         throw e.message;


### PR DESCRIPTION
The mere presence of the `federated` query param causes IdP logout to initiate even if the `federated` flag on `clearSession` is `false`.

This PR only places the `federated` query param if the flag is `true`.